### PR TITLE
fixed workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - master
+    - main
 
 jobs:
   build:


### PR DESCRIPTION
The master branch name is called main (not master). This should fix the workflow and allow the preview release.